### PR TITLE
Length of confirmation code is configurable and set to 32 bytes now.

### DIFF
--- a/web/YbForumConfig.php
+++ b/web/YbForumConfig.php
@@ -81,7 +81,7 @@ class YbForumConfig
      * @var boolean If set, the Mailer will not try to send a mail,
      * but just log to syslog and stderr what would be sent as a mail.
      */
-    const MAIL_DEBUG = true;
+    const MAIL_DEBUG = false;
 
     /**
     * @var string Address to use as mail from address
@@ -121,6 +121,11 @@ class YbForumConfig
      * like 20min are trying to post..
      */
     const LOG_EXT_POST_DATA_ON_AUTH_FAILURE = true;
+
+    /**
+     * Number of random bytes to use for all confirmation codes generated
+     */
+    const CONFIRMATION_CODE_LENGTH = 32;
 
     /**
      * @var bool If true, a stand with ukraine logo is rendered

--- a/web/model/ForumDb.php
+++ b/web/model/ForumDb.php
@@ -531,7 +531,7 @@ class ForumDb extends PDO
         // delete an eventually already existing entry first
         $this->RemoveConfirmUserCode($userId);        
         // generate some random bytes to be used as confirmation code
-        $bytes = random_bytes(64);
+        $bytes = random_bytes(YbForumConfig::CONFIRMATION_CODE_LENGTH);
         $confirmCode = mb_strtoupper(bin2hex($bytes), 'UTF-8');
         // and hash the new password
         $hashedPass = password_hash($newPasswordClearText, PASSWORD_DEFAULT);
@@ -737,7 +737,7 @@ class ForumDb extends PDO
         // Delete any already existing entry first
         $this->RemoveResetPasswordCode($user->GetId());
         // Create some randomness and insert as new entry
-        $bytes = random_bytes(64);
+        $bytes = random_bytes(YbForumConfig::CONFIRMATION_CODE_LENGTH);
         $confirmCode = mb_strtoupper(bin2hex($bytes), 'UTF-8');
         // insert it into the reset password table
         $insertQuery = 'INSERT INTO reset_password_table '
@@ -864,7 +864,7 @@ class ForumDb extends PDO
         $this->RemoveUpdateEmailCode($userId);
         
         // generate some random bytes to be used as confirmation code
-        $bytes = random_bytes(64);
+        $bytes = random_bytes(YbForumConfig::CONFIRMATION_CODE_LENGTH);
         $confirmCode = mb_strtoupper(bin2hex($bytes), 'UTF-8');
         
         // insert it into the update_email_table


### PR DESCRIPTION
Default to MAIL_DEBUG=false